### PR TITLE
Implement user homepage and (more) sketch tests.

### DIFF
--- a/codebender_testing/config.py
+++ b/codebender_testing/config.py
@@ -6,9 +6,15 @@ from selenium import webdriver
 # URL of the site to be used for testing
 BASE_URL = "http://localhost"
 
+# URL of the actual Codebender website
+LIVE_SITE_URL = "http://codebender.cc"
 
 _EXTENSIONS_DIR = 'extensions'
 _FIREFOX_EXTENSION_FNAME = 'codebender.xpi'
+
+# Files used for testing
+TEST_DATA_DIR = 'test_data'
+TEST_DATA_BLANK_PROJECT = os.path.join(TEST_DATA_DIR, 'blank_project.ino')
 
 # Set up Selenium Webdrivers to be used for selenium tests
 

--- a/codebender_testing/utils.py
+++ b/codebender_testing/utils.py
@@ -2,6 +2,7 @@ import re
 
 from selenium import webdriver
 from selenium.common.exceptions import NoSuchElementException
+from selenium.webdriver.common.by import By
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.support import expected_conditions
 from selenium.webdriver.support.ui import WebDriverWait
@@ -28,7 +29,7 @@ class SeleniumTestCase(object):
         cls.driver = webdriver
 
     @pytest.fixture(scope="class")
-    def tester_login(self): 
+    def tester_login(self):
         self.login()
 
     def open(self, url=None):
@@ -77,6 +78,16 @@ class SeleniumTestCase(object):
         """Waits for an element specified by *locator (a tuple of
         (By.<something>, str)), then returns it if it is found."""
         WebDriverWait(self.driver, ELEMENT_FIND_TIMEOUT).until(
-            expected_conditions.presence_of_element_located(locator))
+            expected_conditions.visibility_of_element_located(locator))
         return self.driver.find_element(*locator)
-        
+
+    def delete_project(self, project_name):
+        """Deletes the project specified by `project_name`. Note that this will
+        navigate to the user's homepage."""
+        self.open('/')
+        created_project = self.get_element(By.LINK_TEXT, project_name)
+        delete_button_li = created_project.find_element_by_xpath('..')
+        delete_button = delete_button_li.find_element_by_css_selector('button:last-child')
+        delete_button.click()
+        popup_delete_button = self.get_element(By.ID, 'deleteProjectButton')
+        popup_delete_button.click()

--- a/test_data/blank_project.ino
+++ b/test_data/blank_project.ino
@@ -1,0 +1,10 @@
+/** 
+ * A blank Arduino project.
+ * This should compile with no issues.
+ */
+
+void setup() {
+}
+
+void loop() {
+}

--- a/tests/sketch/test_sketch.py
+++ b/tests/sketch/test_sketch.py
@@ -31,7 +31,7 @@ class TestSketch(SeleniumTestCase):
         # I get a StaleElementReferenceException without
         # this wait. TODO: figure out how to get around this.
         time.sleep(3)
- 
+
     def test_verify_code(self):
         """Ensures that we can compile code and see the success message."""
         compile_button = self.driver.find_element_by_id("compile")
@@ -69,10 +69,29 @@ class TestSketch(SeleniumTestCase):
         """Tests that the speeds dropdown exists."""
         self.get_element(By.ID, "baudrates")
 
+    def test_serial_monitor_disables_fields(self):
+        """Tests that opening the serial monitor disables the port and baudrate
+        fields."""
+        open_serial_monitor_button = self.get_element(By.ID, 'toggle_connect_serial')
+        open_serial_monitor_button.click()
+
+        baudrate_field = self.get_element(By.ID, 'baudrates_placeholder')
+        assert baudrate_field.get_attribute('disabled') == 'true'
+
+        ports_field = self.get_element(By.ID, 'ports_placeholder')
+        assert ports_field.get_attribute('disabled') == 'true'
+
+
     def test_clone_project(self):
         """Tests that clicking the 'Clone Project' link brings us to a new
         sketch with the title 'test_project clone'."""
         clone_link = self.get_element(By.LINK_TEXT, 'Clone Project')
         clone_link.click()
         project_name = self.get_element(By.ID, 'editor_heading_project_name')
+        # Here, I use `startswith` in case the user has a bunch of
+        # projects like "test_project copy copy copy" ...
         assert project_name.text.startswith("%s copy" % TEST_PROJECT_NAME)
+
+        # Cleanup: delete the project we just created.
+        self.delete_project("%s copy" % TEST_PROJECT_NAME)
+

--- a/tests/user_home/test_user_home.py
+++ b/tests/user_home/test_user_home.py
@@ -1,0 +1,54 @@
+from selenium.webdriver.common.by import By
+import pytest
+
+from codebender_testing.config import TEST_DATA_BLANK_PROJECT
+from codebender_testing.utils import SeleniumTestCase
+
+
+# Name to be used for the new project that is created.
+NEW_PROJECT_NAME = 'selenium_TestUserHome'
+
+class TestUserHome(SeleniumTestCase):
+
+    @pytest.fixture(scope="class", autouse=True)
+    def open_user_home(self, tester_login):
+        """Makes sure we are logged in and are at the user home page
+        performing any of these tests."""
+        pass
+
+    def test_create_project_blank_name(self):
+        """Test that we get an error when creating a project with no name."""
+        create_button = self.get_element(By.CSS_SELECTOR, '.form-search button')
+        create_button.click()
+        error_heading = self.get_element(By.CSS_SELECTOR, '.alert h4')
+        assert error_heading.text.startswith('Error')
+
+    def test_create_project_invalid_name(self):
+        """Test that we get an error when creating a project with an
+        invalid name (e.g., a name containing a backslash).
+        """
+        project_name_input = self.get_element(By.CSS_SELECTOR,
+                                              '.form-search input[type=text]')
+        project_name_input.clear()
+        project_name_input.send_keys('foo\\bar')
+        create_button = self.get_element(By.CSS_SELECTOR, '.form-search button')
+        create_button.click()
+
+        error_heading = self.get_element(By.CSS_SELECTOR, '.alert h4')
+        assert error_heading.text.startswith('Error')
+
+    def test_create_project_valid_name(self):
+        """Test that we can successfully create a project with a valid name."""
+        project_name_input = self.get_element(By.CSS_SELECTOR,
+                                              '.form-search input[type=text]')
+        project_name_input.clear()
+        project_name_input.send_keys(NEW_PROJECT_NAME)
+        create_button = self.get_element(By.CSS_SELECTOR, '.form-search button')
+        create_button.click()
+
+        project_heading = self.get_element(By.ID, 'editor_heading_project_name')
+        assert project_heading.text == NEW_PROJECT_NAME
+
+        # Cleanup: delete the project we just created.
+        self.delete_project(NEW_PROJECT_NAME)
+


### PR DESCRIPTION
From #1, I've implemented the following checked items in this pull request:

User's homepage
- [x] Create new project with no project name
- [x] Create new project with valid project name
- [x] Create new project with invalid name (e.g. backslashes in project name)

Sketch page
- [x] Open Serial Monitor with empty ports dropdown

As @hciwork has noted in #2, it's tricky to test uploads. It's not possible to do with Selenium alone, unless the upload occurs via an `<input type="upload">` element, in which case the absolute path of the file can be directly entered using `send_keys`. Otherwise, it's necessary to use some sort of library to interact with the file upload dialogue box. It may or may not be possible to achieve this with [Robot Framework](http://robotframework.org/). I'm looking into it.

Update: the following from #1 are resolved in #7:

- [x] Upload project (single file)
- [x] Upload project (need to test zip functionality, is that possible?)