### PR TITLE
Miscellaneous improvements and bugfixes (see description)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,130 @@
 # Codebender Selenium Tests
 
-This repo contains Selenium tests for the codebender website.
-The tests are written in Python 3.
+This repo contains Selenium tests for the codebender website.  The tests are
+written in Python 3, and utilize pytest as a testing framework and Selenium
+for browser automation.
 
 ## Running Tests
 
-To run tests locally, you'll need to be running a selenium server. See
-[here](https://selenium-python.readthedocs.org/installation.html#downloading-selenium-server)
-for instructions.
+### Dependencies
 
-Once you've got a Selenium server running, simply run `$ tox` from within the
-repo. If you don't have tox, run `$ sudo pip3 install -r requirements-dev.txt`
-from within the repo to install it.
+To run these tests, you'll need to have Python 3 installed. In addition, it is
+advantageous to have pip, a package manager for Python, in order to install
+dependencies.
+
+Notably, the pip2 (for Python 2) and pip3 (for Python 3) packages both attempt
+to link `/usr/local/bin/pip` to the `pip2` or `pip3` executable, respectively.
+To deal with this, you could explicitly type out `pip3` or `pip2` instead of
+`pip` whenever you use pip via the command line. (It may be best to just remove
+`/usr/local/bin/pip` entirely).
+
+To install `pip` in Ubuntu, run `$ sudo apt-get install python3
+python3-setuptools`, then `$ sudo easy_install3 pip`.
+
+After getting set up with pip and cloning the seleniumTests repo, you should
+make sure to install all the seleniumTests dependencies by `cd`ing to your local
+clone of the repo and running `$ sudo pip3 install -r requirements-dev.txt`.
+
+### Invoking Tests via `tox`
+
+After installing dependencies, you should have the `tox` command available. To
+run all of the tests, you can simply run `$ tox` from within the cloned repo.
+
+You can also run individual tests by providing the appropriate directory or
+filename as an argument, for example: `$ tox tests/sketch`.
+
+Invoking tox will also run `flake8`, which is essentially a lint checker for
+Python. It is best to fix any issues reported by `flake8` before committing
+to the repo. It can be run on its own via the command `$ flake8`.
+
+#### Specifying a URL for Tests
+
+Tests can either be run for the
+[bachelor](https://github.com/codebendercc/bachelor) version of the site,
+running locally, or for the live site. The version of the site that is running
+is inferred from the `--url` parameter. You can run `$ tox --url
+http://localhost` to run the tests for a locally running bachelor site (this is
+the default url), or `$ tox --url http://codebender.cc` to run the tests for the
+live site.
+
+Certain tests are specially written for one site or the other. This is
+implemented with a custom `pytest` marker. Tests that require a certain `--url`
+are decorated with `@pytest.mark.requires_url(<url>)`.
+
+### Changing Test Configuration
+
+Various global configuration parameters are specified in
+`codebender_testing/config.py`.  Such parameters include URLs and site endpoints
+which are subject to change.  This is also where the webdrivers (Firefox and
+Chrome) are specified.
+
+## Compilation Logs
+
+Certain tests exist to iterate through groups of sketches and compile them
+one-by-one.  Since these tests take a long time, they are not run in full by
+default. You can run them by specifying the `--full` option; for example: `$ tox
+tests/cb_compile_tester --full`.
+
+The following test cases are compile tests that generate such logs:
+- `tests/libraries/test_libraries.py::TestLibraryExamples`
+- `tests/compile_tester/test_compile_tester_projects.py::TestCompileTester`
+
+The generated logs are placed in the `logs` directory. They give detailed output
+in JSON format containing the codebender site URL that was used to run the
+tests, along with the URLs of the individual sketches that were compiled, and
+whether they succeeded or failed to compile.
+
+## Framework Overview
+
+The following outlines the structure of the repository as well as important
+framework components.
+
+### Directory Structure
+
+#### `tests/`
+
+The `tests/` directory contains all of the actual unit tests for the codebender
+site. That is, all of the tests discovered by `py.test` should come from this
+directory.
+
+**`tests/conftest.py`** contains the global configuration for pytest,
+including specifying the webdriver fixtures as well as the available command
+line arguments.
+
+#### `codebender_testing/`
+
+This is where all major components of the testing framework live. All of the
+unit tests rely on the files in this directory.
+
+**`codebender_testing/config.py`** specifies global configuration parameters for
+testing (see "Changing Test Configuration" above).
+
+**`codebender_testing/utils.py`** defines codebender-specific utilities used to
+test the site. These mostly consist of abstractions to the Selenium framework.
+The most important class is `SeleniumTestCase`, which all of the unit test cases
+inherit from. This grants them access (via `self`) to a number of methods and
+attributes that are useful for performing codebender-specific actions.
+
+#### `batch/`
+
+The `batch/` directory contains any executable scripts not directly used to
+perform tests. For example, it contains a script `fetch_projects.py` which can
+be used to download all of the public projects of a particular codebender user.
+
+#### `extensions/`
+
+The `extensions/` directory contains the codebender browser extensions to be
+used by the Selenium webdrivers.
+
+#### `test_data/`
+
+The `test_data/` directory contains any data used for testing. For example, it
+contains example projects that we should successfully be able to upload and
+compile.
+
+#### `logs/`
+
+The `logs/` directory contains the results of running certain tests, e.g.
+whether certain sets of sketches have compiled successfully (see "Compilation
+Logs").
 

--- a/codebender_testing/config.py
+++ b/codebender_testing/config.py
@@ -38,8 +38,8 @@ TEST_DATA_BLANK_PROJECT_ZIP = os.path.join(TEST_DATA_DIR, 'blank_project.zip')
 # Directory in which the local compile tester files are stored.
 COMPILE_TESTER_DIR = os.path.join(TEST_DATA_DIR, 'cb_compile_tester')
 
-# Set up Selenium Webdrivers to be used for selenium tests
 
+# Set up Selenium Webdrivers to be used for selenium tests
 def _get_firefox_profile():
     """Returns the Firefox profile to be used for the FF webdriver.
     Specifically, we're equipping the webdriver with the Codebender
@@ -59,7 +59,7 @@ def _get_firefox_profile():
 # module is imported (hence the need for lazy evaluation).
 WEBDRIVERS = {
     "firefox": lambda: webdriver.Firefox(firefox_profile=_get_firefox_profile()),
-#   "chrome": lambda: webdriver.Chrome()
+    # "chrome": lambda: webdriver.Chrome()
 }
 
 # Credentials to use when logging into the site via selenium

--- a/codebender_testing/config.py
+++ b/codebender_testing/config.py
@@ -51,8 +51,15 @@ def _get_firefox_profile():
     )
     return firefox_profile
 
+# Webdrivers to be used for testing. Specifying additional webdrivers here
+# will cause every test to be re-run using that webdriver.
+# These webdrivers are specified as lambdas to allow for "lazy" evaluation.
+# The lambda invocation will return the actual webdriver and open up a
+# browser window, and we don't want a browser window to open whenever this
+# module is imported (hence the need for lazy evaluation).
 WEBDRIVERS = {
-    "firefox": webdriver.Firefox(firefox_profile=_get_firefox_profile())
+    "firefox": lambda: webdriver.Firefox(firefox_profile=_get_firefox_profile()),
+#   "chrome": lambda: webdriver.Chrome()
 }
 
 # Credentials to use when logging into the site via selenium

--- a/codebender_testing/utils.py
+++ b/codebender_testing/utils.py
@@ -4,6 +4,7 @@ from time import strftime
 import json
 import os
 import re
+import shutil
 import tempfile
 
 from selenium.common.exceptions import NoSuchElementException
@@ -77,9 +78,8 @@ def temp_copy(fname):
     """
     extension = fname.split('.')[-1]
     with tempfile.NamedTemporaryFile(mode='w+b', suffix='.%s' % extension) as copy:
-        with open(fname, 'r') as original:
-            for line in original:
-                copy.write(line)
+        with open(fname, 'rb') as original:
+            shutil.copyfileobj(original, copy)
         copy.flush()
         yield copy
 

--- a/codebender_testing/utils.py
+++ b/codebender_testing/utils.py
@@ -101,7 +101,7 @@ class CodebenderSeleniumBot(object):
         """
         if webdriver is None:
             webdriver = WEBDRIVERS.keys()[0]
-        self.driver = WEBDRIVERS[webdriver]
+        self.driver = WEBDRIVERS[webdriver]()
 
         if url is None:
             url = BASE_URL

--- a/codebender_testing/utils.py
+++ b/codebender_testing/utils.py
@@ -287,9 +287,13 @@ class CodebenderSeleniumBot(object):
         format string, which will be formatted appropriately.
         `iframe` specifies whether the urls pointed to by `selector` are contained
         within an iframe.
+        If the `--full` argument is provided (and hence
+        `self.run_full_compile_tests` is `True`, we do not log, and limit the
+        number of sketches compiled to 1.
         """
-        if logfile is None:
-            for sketch in sketches:
+        sketch_limit = None if self.run_full_compile_tests else 1
+        if logfile is None or not self.run_full_compile_tests:
+            for sketch in sketches[:sketch_limit]:
                 self.compile_sketch(sketch, iframe=iframe)
         else:
             log_entry = {'url': self.site_url, 'succeeded': [], 'failed': []}
@@ -322,7 +326,7 @@ class SeleniumTestCase(CodebenderSeleniumBot):
 
     @classmethod
     @pytest.fixture(scope="class", autouse=True)
-    def _testcase_attrs(cls, webdriver, testing_url):
+    def _testcase_attrs(cls, webdriver, testing_url, testing_full):
         """Sets up any class attributes to be used by any SeleniumTestCase.
         Here, we just store fixtures as class attributes. This allows us to avoid
         the pytest boilerplate of getting a fixture value, and instead just
@@ -330,6 +334,7 @@ class SeleniumTestCase(CodebenderSeleniumBot):
         """
         cls.driver = webdriver
         cls.site_url = testing_url
+        cls.run_full_compile_tests = testing_full
 
     @pytest.fixture(scope="class")
     def tester_login(self):

--- a/codebender_testing/utils.py
+++ b/codebender_testing/utils.py
@@ -203,6 +203,15 @@ class CodebenderSeleniumBot(object):
             # 'Log In' is not displayed, so we're already logged in.
             pass
 
+    def logout(self):
+        """Logs out of the site."""
+        try:
+            logout_button = self.driver.find_element_by_id("logout")
+            logout_button.send_keys(Keys.ENTER)
+        except NoSuchElementException:
+            # 'Log out' is not displayed, so we're already logged out.
+            pass
+
     def get_element(self, *locator):
         """Waits for an element specified by *locator (a tuple of
         (By.<something>, str)), then returns it if it is found."""
@@ -217,11 +226,11 @@ class CodebenderSeleniumBot(object):
             expected_conditions.visibility_of_all_elements_located_by(locator))
         return self.driver.find_elements(*locator)
 
-    def get(self, selector):
+    def find(self, selector):
         """Alias for `self.get_element(By.CSS_SELECTOR, selector)`."""
         return self.get_element(By.CSS_SELECTOR, selector)
 
-    def get_all(self, selector):
+    def find_all(self, selector):
         """Alias for `self.get_elements(By.CSS_SELECTOR, selector)`."""
         return self.get_elements(By.CSS_SELECTOR, selector)
 
@@ -339,6 +348,10 @@ class SeleniumTestCase(CodebenderSeleniumBot):
     @pytest.fixture(scope="class")
     def tester_login(self):
         self.login()
+
+    @pytest.fixture(scope="class")
+    def tester_logout(self):
+        self.logout()
 
 
 class VerificationError(Exception):

--- a/tests/compile_tester/test_compile_tester_projects.py
+++ b/tests/compile_tester/test_compile_tester_projects.py
@@ -28,8 +28,10 @@ class TestCompileTester(SeleniumTestCase):
         """Tests that we can upload all of cb_compile_tester's projects
         (stored locally in test_data/cb_compile_tester), compile them,
         and finally delete them."""
+        upload_limit = None if self.run_full_compile_tests else 1
+
         test_files = [os.path.join(COMPILE_TESTER_DIR, name)
-            for name in next(os.walk(COMPILE_TESTER_DIR))[2]]
+            for name in next(os.walk(COMPILE_TESTER_DIR))[2]][:upload_limit]
         projects = [self.upload_project(fname) for fname in test_files]
         project_names, project_urls = zip(*projects)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,11 +26,18 @@ def pytest_addoption(parser):
     """Adds command line options to py.test."""
     parser.addoption("--url", action="store", default=BASE_URL,
                      help="URL to use for testing, e.g. http://localhost, http://codebender.cc")
+    parser.addoption("--full", action="store_true", default=False,
+                     help="Whether to run the complete set of compile tests.")
 
 @pytest.fixture(scope="class")
 def testing_url(request):
     """A fixture to get the --url parameter."""
     return request.config.getoption("--url")
+
+@pytest.fixture(scope="class")
+def testing_full(request):
+    """A fixture to get the --full parameter."""
+    return request.config.getoption("--full")
 
 @pytest.fixture(autouse=True)
 def skip_by_site(request, testing_url):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,11 @@
+"""The configuration file for `py.test`.
+
+This file specifies global test fixtures, which include the selenium
+webdrivers.
+
+This is also where command-line arguments are defined.
+"""
+
 import pytest
 
 from codebender_testing.config import BASE_URL
@@ -10,7 +18,7 @@ def webdriver(request):
     and registers a finalizer to close the browser once the session is
     complete. The entire test session is repeated once per driver.
     """
-    driver = WEBDRIVERS[request.param]
+    driver = WEBDRIVERS[request.param]()
     request.addfinalizer(lambda: driver.quit())
     return driver
 
@@ -21,6 +29,7 @@ def pytest_addoption(parser):
 
 @pytest.fixture(scope="class")
 def testing_url(request):
+    """A fixture to get the --url parameter."""
     return request.config.getoption("--url")
 
 @pytest.fixture(autouse=True)
@@ -29,5 +38,7 @@ def skip_by_site(request, testing_url):
     if request.node.get_marker('requires_url'):
         required_url = request.node.get_marker('requires_url').args[0]
         if required_url.rstrip('/') != testing_url.rstrip('/'):
-            pytest.skip('skipped test that requires --url=%s')
+            pytest.skip('skipped test that requires --url=%s' % required_url)
+
+# TODO: add a --full option to run the complete test suite.
 

--- a/tests/home/test_home.py
+++ b/tests/home/test_home.py
@@ -4,27 +4,27 @@ from selenium.webdriver.common.keys import Keys
 
 class TestHome(SeleniumTestCase):
 
-    def test_navigate_home(self):
+    def test_navigate_home(self, tester_logout):
         """ opens browser to codebender bachelor """
         self.open("/")
         assert "Codebender" in self.driver.title
 
-    def test_login(self):
+    def test_login(self, tester_logout):
         driver = self.driver
         self.open("/")
 
-        """ tests to ensure login div appears """        
+        """ tests to ensure login div appears """
         login_elem = driver.find_element_by_id("login_btn")    #finds login button
         login_elem.send_keys(Keys.RETURN)                      #clicks login button
         logbox_elem = driver.find_element_by_id("login_box")   #finds login div
         assert logbox_elem.is_displayed()                      #checks to see if div is visible
 
         """ tests login with invalid username """
-        # define elements in login form 
+        # define elements in login form
         username_elem = driver.find_element_by_id("username")
         password_elem = driver.find_element_by_id("password")
         submit_elem = driver.find_element_by_id("_submit")
-        
+
         # enter invalid username with correct password
         username_elem.send_keys("codebender")
         password_elem.send_keys(TEST_CREDENTIALS['password'])
@@ -32,7 +32,7 @@ class TestHome(SeleniumTestCase):
 
         # check for error message
         error_elem = driver.find_element_by_class_name('text-error')
-        assert error_elem.is_displayed() 
+        assert error_elem.is_displayed()
 
         """ tests login with invalid password """
         # refresh page so error message no longer visible
@@ -40,13 +40,13 @@ class TestHome(SeleniumTestCase):
 
         # re-click on login button
         login_elem = driver.find_element_by_id("login_btn")
-        login_elem.send_keys(Keys.RETURN) 
- 
-        # re-define elements in login form 
+        login_elem.send_keys(Keys.RETURN)
+
+        # re-define elements in login form
         username_elem = driver.find_element_by_id("username")
         password_elem = driver.find_element_by_id("password")
         submit_elem = driver.find_element_by_id("_submit")
-         
+
         # enter correct username with invalid password
         username_elem.clear()
         username_elem.send_keys(TEST_CREDENTIALS['username'])
@@ -63,9 +63,9 @@ class TestHome(SeleniumTestCase):
 
         # re-click on login button
         login_elem = driver.find_element_by_id("login_btn")
-        login_elem.send_keys(Keys.RETURN) 
- 
-        # re-define elements in login form 
+        login_elem.send_keys(Keys.RETURN)
+
+        # re-define elements in login form
         username_elem = driver.find_element_by_id("username")
         password_elem = driver.find_element_by_id("password")
         submit_elem = driver.find_element_by_id("_submit")
@@ -76,19 +76,4 @@ class TestHome(SeleniumTestCase):
         password_elem.send_keys(TEST_CREDENTIALS['password'])
         submit_elem.click()
         assert "Logged in as" in driver.page_source
-
-    def test_quit(self):
-        """ closes driver """
-        driver = self.driver
-        #driver.quit()
-
-
-
-
-
-
-
-
-
-
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,4 +4,5 @@ envlist = py32
 [testenv]
 deps = -rrequirements.txt
 commands = flake8
-           py.test
+           py.test {posargs} # Pass all command line args from tox to py.test.
+                             # e.g., `tox <foo>` will invoke `py.test <foo>`.


### PR DESCRIPTION
_The diff for this PR includes significant whitespace changes. Click [here](https://github.com/codebendercc/seleniumTests/pull/10/files?w=1) to see the diff with the whitespace changes excluded._

Done in this pull request:
- [x] Fix issue where simply importing `config.py` would start up the Selenium webdriver
- [x] Add `--full` option to testing suite, to select between compiling all of the sketches or just one of them (to test basic functionality); resolves #9
- [x] Greatly improve documentation, mainly in `README.md`
- [x] Fix a few broken tests. (I didn't see that these were breaking before, because I would never run the full test suite due to not having the `--full` option). _EDIT: fixed. There was a bug with `codebender_testing/utils.py::temp_copy`._
- [x] Fix some flaky tests (most importantly, the login test needs to require a "logout" fixture, otherwise it will fail if already logged in)
- Fix all `flake8` warnings (Python style issues), e.g. unused imports, lines too long, trailing whitespace. There are a _ton_ of these so I may actually do this in a separate PR. (EDIT: I will fix this in a separate pull request)