### PR TITLE
Create Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,31 @@
 # Dockerfile to build container with Codebender selenium tests.
 
 FROM ubuntu:12.04
-# TODO: add maintainer.
+# TODO: add MAINTAINER
+
+# Install minimal dev utilities
+RUN apt-get update
+RUN apt-get install -y git vim
 
 # Install Python and necessary utilities
-RUN apt-get update
 RUN apt-get install -y python3 python3-setuptools
-RUN apt-get clean
 RUN easy_install3 pip
+RUN pip install -U setuptools
+
+# Install web browsers for local testing
+RUN apt-get install -y firefox
+
+# Cleanup
+RUN apt-get clean
 
 # Add source code and install dependencies
 RUN mkdir -p /opt/codebender
 ADD . /opt/codebender/seleniumTests
 WORKDIR /opt/codebender/seleniumTests
-RUN ls -l
 RUN pip3 install -r requirements-dev.txt
 
 # Specify a default command for the container.
-# Right now we simply run ls. TODO: run tests.
+# Right now we simply run bash. TODO: add ENTRYPOINT for running tests.
 WORKDIR /opt/codebender/seleniumTests
-CMD ["ls", "-l"]
+CMD ["/bin/bash"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+# Dockerfile to build container with Codebender selenium tests.
+
+FROM ubuntu:12.04
+# TODO: add maintainer.
+
+# Install Python and necessary utilities
+RUN apt-get update
+RUN apt-get install -y python3 python3-setuptools
+RUN apt-get clean
+RUN easy_install3 pip
+
+# Add source code and install dependencies
+RUN mkdir -p /opt/codebender
+ADD . /opt/codebender/seleniumTests
+WORKDIR /opt/codebender/seleniumTests
+RUN ls -l
+RUN pip3 install -r requirements-dev.txt
+
+# Specify a default command for the container.
+# Right now we simply run ls. TODO: run tests.
+WORKDIR /opt/codebender/seleniumTests
+CMD ["ls", "-l"]
+


### PR DESCRIPTION
This PR introduces a Dockerfile which bootstraps an Ubuntu 12.04 image so that it can run our tests. If you have Docker installed you should be able to run `$ docker build -t codebender/seleniumtests .` to build the image. Then find its ID using `$ docker images` and run `$ docker run <id>`.

Note that we aren't running the tests quite yet so this PR is on hold; details of exactly how that is supposed to be done still need to get worked out. In particular we can't simply run `tox` unless this same image also runs the virtual web browsers. That is doable (see [here](http://www.function.fr/docker-with-chrome-and-selenium-and-firefox/)), but we also should consider [Sauce](https://saucelabs.com/) for testing.

As of right now the installation of all the dependencies is successful and I am able to see all the code correctly copied to `/opt/codebender/seleniumTests`.