### PR TITLE
Removing temporary browser's profile directory from /tmp when webdriver quits

### DIFF
--- a/codebender_testing/config.py
+++ b/codebender_testing/config.py
@@ -122,6 +122,7 @@ def create_webdriver(command_executor, desired_capabilities):
     # missing from the desired_capabilities dict above.
     _capabilities = desired_capabilities
     browser_profile = None
+    browser_profile_path = None
 
     if browser_name == "chrome":
         desired_capabilities = DesiredCapabilities.CHROME.copy()
@@ -149,12 +150,16 @@ def create_webdriver(command_executor, desired_capabilities):
         desired_capabilities = DesiredCapabilities.FIREFOX.copy()
         desired_capabilities.update(_capabilities)
         browser_profile = _get_firefox_profile()
+        browser_profile_path = browser_profile.path
         browser_profile.set_preference("general.useragent.override", TESTS_USER_AGENT)
         desired_capabilities["firefox_profile"] = browser_profile.update_preferences()
     else:
         raise ValueError("Invalid webdriver %s (only chrome and firefox are supported)" % browser_name)
-    return webdriver.Remote(
-        command_executor=command_executor,
-        desired_capabilities=desired_capabilities,
-        browser_profile=browser_profile,
-    )
+    return {
+        'driver': webdriver.Remote(
+            command_executor=command_executor,
+            desired_capabilities=desired_capabilities,
+            browser_profile=browser_profile,
+        ),
+        'profile_path': browser_profile_path
+    }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,7 @@ This is also where command-line arguments and pytest markers are defined.
 
 import os
 import sys
+import shutil
 
 import pytest
 
@@ -55,7 +56,9 @@ def webdriver(request, desired_capabilities):
 
     command_executor = os.environ['CODEBENDER_SELENIUM_HUB_URL']
 
-    driver = config.create_webdriver(command_executor, desired_capabilities)
+    webdriver = config.create_webdriver(command_executor, desired_capabilities)
+    driver = webdriver['driver']
+    profile_path = webdriver['profile_path']
 
     # TODO: update sauce status via SauceClient, but only if the command_executor
     # is a sauce URL.
@@ -70,6 +73,9 @@ def webdriver(request, desired_capabilities):
             #     sauce.jobs.update_job(driver.session_id, passed=False)
         finally:
             driver.quit()
+            if profile_path and os.path.exists(profile_path):
+                print '\n\nRemoving browser profile directory:', profile_path
+                shutil.rmtree(profile_path, ignore_errors=True)
 
     request.addfinalizer(finalizer)
     return driver


### PR DESCRIPTION
### Changes:
- Removing temporary browser profile created at: /tmp

Fixes pilling of old temporary profile directories in /tmp after multiple run of the tests.