### PR TITLE
Stopping tests when Disqus API rate limit reached

### DIFF
--- a/bin/seleniumbender.py
+++ b/bin/seleniumbender.py
@@ -69,18 +69,20 @@ class Tests:
         logfile_timestamp = re.match(r'(\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2})-.+', logfile).group(1)
 
         report_regexp = re.compile('report_{timestamp}-{identifier}_(\d+)'.format(timestamp=logfile_timestamp, identifier=identifier))
-        reportfile = sorted([filename for filename in os.listdir(reports) if filename not in self.files_to_ignore and report_regexp.match(filename)], reverse=True)[0]
-        changes = report_regexp.match(reportfile).group(1)
+        reportfile = sorted([filename for filename in os.listdir(reports) if filename not in self.files_to_ignore and report_regexp.match(filename)], reverse=True)
+        if reportfile:
+            reportfile = reportfile[0]
+            changes = report_regexp.match(reportfile).group(1)
 
-        email_date = time.strftime('%Y-%m-%d %H:%M:%S')
+            email_date = time.strftime('%Y-%m-%d %H:%M:%S')
 
-        command = [
-            '(echo "Changes since the last time: {changes}";'.format(changes=changes),
-            'uuencode "{logs}/{logfile}" "{logfile}";'.format(logs=logs, logfile=logfile),
-            'uuencode "{reports}/{reportfile}" "{reportfile}")'.format(reports=reports, reportfile=reportfile),
-            '| mail -s "Selenium Tests Report: {identifier} {email_date} Changes: {changes}" {email}'.format(identifier=identifier, email_date=email_date, changes=changes, email=self.email)
-        ]
-        self.run_command(command)
+            command = [
+                '(echo "Changes since the last time: {changes}";'.format(changes=changes),
+                'uuencode "{logs}/{logfile}" "{logfile}";'.format(logs=logs, logfile=logfile),
+                'uuencode "{reports}/{reportfile}" "{reportfile}")'.format(reports=reports, reportfile=reportfile),
+                '| mail -s "Selenium Tests Report: {identifier} {email_date} Changes: {changes}" {email}'.format(identifier=identifier, email_date=email_date, changes=changes, email=self.email)
+            ]
+            self.run_command(command)
 
     def create_command(self, test_directory, *extra_arguments):
         return ['tox', 'tests/' + test_directory, '--', '--url={}'.format(TARGETS[self.url])] + list(extra_arguments)

--- a/codebender_testing/utils.py
+++ b/codebender_testing/utils.py
@@ -911,9 +911,7 @@ class CodebenderSeleniumBot(object):
         privateRadioButton.click()
 
     def change_name(self, name):
-        print name
         nameField = self.get_element(By.CSS_SELECTOR,'#create-sketch-modal .modal-body [id="create-sketch-name"')
-        print nameField
         nameField.clear()
         nameField.send_keys(name)
         nameField.send_keys(Keys.ENTER)

--- a/codebender_testing/utils.py
+++ b/codebender_testing/utils.py
@@ -543,6 +543,7 @@ class CodebenderSeleniumBot(object):
 
         print '\nVisiting:', len(urls_to_visit), 'URLs'
         tic = time.time()
+        toc = tic
         for url in urls_to_visit:
             self.open(url)
             self.get_element(By.CSS_SELECTOR, '#mycontainer')
@@ -577,6 +578,8 @@ class CodebenderSeleniumBot(object):
                 return
 
         report_creator('fetch', log_entry, log_file)
+
+        print '\nTest duration:', int(toc - tic), 'sec'
 
     def compile_sketch(self, url, boards, iframe=False, project_view=False):
         """Compiles the sketch located at `url`, or an iframe within the page
@@ -643,6 +646,7 @@ class CodebenderSeleniumBot(object):
 
         total_sketches = len(urls_to_visit)
         tic = time.time()
+        toc = tic
         library_re = re.compile(r'^(.+)/library/.+$')
 
         for url in urls_to_visit:
@@ -752,6 +756,7 @@ class CodebenderSeleniumBot(object):
         # Generate a report if requested.
         if compile_type != 'target_library' and create_report and self.run_full_compile_tests:
             report_creator(compile_type, log_entry, log_file)
+
         print '\nTest duration:', int(toc - tic), 'sec'
 
     def compile_all_sketches(self, url, selector, **kwargs):

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ pytest
 selenium
 simplejson
 disqus-python
+requests


### PR DESCRIPTION
- Checking Disqus API rate limit and stopping the test before trying to comment.
This way we prevent leaving libraries/examples without comments.
- Minor fix in tic-toc intialization at utils.py .
- Added check in seleniumbender.py before sending email with report.
If a report doesn't exists, no email is send.
- Removed unnecessary prints from utilis.py .